### PR TITLE
更改数据路径；增加指令；其他优化

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,5 @@ repositories {
 
 dependencies{
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
-    implementation 'me.liuwj.ktorm:ktorm-core:3.1.0'
+    implementation 'org.ktorm:ktorm-core:3.5.0'
 }

--- a/src/main/kotlin/XXYan.kt
+++ b/src/main/kotlin/XXYan.kt
@@ -7,8 +7,6 @@ import kotlinx.coroutines.withContext
 import com.github.core.MessagePainter
 import com.github.core.data.Sender
 import com.github.core.data.Yan
-import me.liuwj.ktorm.entity.add
-import me.liuwj.ktorm.entity.toList
 import net.mamoe.mirai.console.command.CommandManager.INSTANCE.register
 import net.mamoe.mirai.console.permission.PermissionId
 import net.mamoe.mirai.console.permission.PermissionService
@@ -20,6 +18,8 @@ import net.mamoe.mirai.event.events.GroupMessageEvent
 import net.mamoe.mirai.event.globalEventChannel
 import net.mamoe.mirai.message.code.MiraiCode.deserializeMiraiCode
 import net.mamoe.mirai.utils.ExternalResource.Companion.toExternalResource
+import org.ktorm.entity.add
+import org.ktorm.entity.toList
 import java.io.ByteArrayOutputStream
 import java.net.URL
 import java.util.concurrent.ThreadLocalRandom

--- a/src/main/kotlin/XXYan.kt
+++ b/src/main/kotlin/XXYan.kt
@@ -1,5 +1,6 @@
 package com.github
 
+import com.github.commands.YanConsoleCommands
 import com.github.commands.YanCommand
 import com.github.commands.YanCommands
 import kotlinx.coroutines.Dispatchers
@@ -12,7 +13,6 @@ import net.mamoe.mirai.console.permission.PermissionId
 import net.mamoe.mirai.console.permission.PermissionService
 import net.mamoe.mirai.console.plugin.jvm.JvmPluginDescription
 import net.mamoe.mirai.console.plugin.jvm.KotlinPlugin
-import net.mamoe.mirai.contact.nameCardOrNick
 import net.mamoe.mirai.event.ListeningStatus
 import net.mamoe.mirai.event.events.GroupMessageEvent
 import net.mamoe.mirai.event.globalEventChannel
@@ -21,7 +21,6 @@ import net.mamoe.mirai.utils.ExternalResource.Companion.toExternalResource
 import org.ktorm.entity.add
 import org.ktorm.entity.toList
 import java.io.ByteArrayOutputStream
-import java.net.URL
 import java.util.concurrent.ThreadLocalRandom
 import javax.imageio.ImageIO
 import kotlin.random.asKotlinRandom
@@ -61,6 +60,7 @@ object XXYan : KotlinPlugin(JvmPluginDescription(
         YanCommands.register()
         Class.forName("org.sqlite.JDBC")
         YanCommand.register()
+        YanConsoleCommands.register()
         YanConfig.reload()
         globalEventChannel().subscribe<GroupMessageEvent> {
             if (sender.id in YanConfig.cares.values && this.message.contentToString() != "") {

--- a/src/main/kotlin/YanConfig.kt
+++ b/src/main/kotlin/YanConfig.kt
@@ -16,6 +16,6 @@ object YanConfig:AutoSavePluginConfig("config") {
     @ValueDescription("这里可以指定字体")
     val font by value("sarasa-ui-tc-regular.ttf")
     @ValueDescription("一个用于指定指令对应触发的列表")
-    val cares:MutableMap<String,Long> by value(mutableMapOf("1" to 1L))
+    val cares:MutableMap<String,Long> by value(mutableMapOf("样例yan" to 1234567L))
 
 }

--- a/src/main/kotlin/YanData.kt
+++ b/src/main/kotlin/YanData.kt
@@ -17,7 +17,7 @@ class YanData(id: Long) : Table<YanEntity>(id.toString()) {
     val title = text("title").bindTo { it.title }
     companion object {
         fun getSequence(id: Long): EntitySequence<YanEntity, YanData> {
-            val database = Database.connect("jdbc:sqlite:data\\yan.db")
+            val database = Database.connect("jdbc:sqlite:file:${XXYan.resolveDataFile("yan.db")}")
             database.useConnection {
                 it.createStatement().execute(
                     """

--- a/src/main/kotlin/YanData.kt
+++ b/src/main/kotlin/YanData.kt
@@ -1,11 +1,13 @@
 package com.github
 
-import me.liuwj.ktorm.database.Database
-import me.liuwj.ktorm.entity.EntitySequence
-import me.liuwj.ktorm.entity.forEach
-import me.liuwj.ktorm.entity.sequenceOf
-import me.liuwj.ktorm.schema.Table
-import me.liuwj.ktorm.schema.text
+import org.ktorm.database.Database
+import org.ktorm.dsl.from
+import org.ktorm.entity.Entity
+import org.ktorm.entity.EntitySequence
+import org.ktorm.entity.sequenceOf
+import org.ktorm.schema.Table
+import org.ktorm.schema.text
+
 
 
 class YanData(id: Long) : Table<YanEntity>(id.toString()) {
@@ -16,12 +18,13 @@ class YanData(id: Long) : Table<YanEntity>(id.toString()) {
     val yan = text("yan").bindTo { it.yan }
     val title = text("title").bindTo { it.title }
     companion object {
-        fun getSequence(id: Long): EntitySequence<YanEntity, YanData> {
-            val database = Database.connect("jdbc:sqlite:file:${XXYan.resolveDataFile("yan.db")}")
+        private val database = Database.connect("jdbc:sqlite:file:${XXYan.resolveDataFile("yan.db")}")
+
+        private fun YanData.createTableIfNotExist() {
             database.useConnection {
                 it.createStatement().execute(
                     """
-                        CREATE TABLE IF NOT EXISTs "${id}"(
+                        CREATE TABLE IF NOT EXISTs "${this@createTableIfNotExist.tableName}"(
                         name TEXT,
                         head TEXT,
                         yan TEXT,
@@ -30,7 +33,13 @@ class YanData(id: Long) : Table<YanEntity>(id.toString()) {
                     """.trimIndent()
                 )
             }
-            return database.sequenceOf(YanData(id))
+        }
+
+
+        fun getSequence(id: Long): EntitySequence<YanEntity, YanData> {
+            val table = YanData(id)
+            table.createTableIfNotExist()
+            return database.sequenceOf(table)
         }
     }
 }

--- a/src/main/kotlin/YanEntity.kt
+++ b/src/main/kotlin/YanEntity.kt
@@ -1,8 +1,8 @@
 package com.github
 
-import me.liuwj.ktorm.entity.Entity
+import org.ktorm.entity.Entity
 
-interface YanEntity:Entity<YanEntity> {
+interface YanEntity: Entity<YanEntity> {
     var name:String
     var head:String
     var yan:String

--- a/src/main/kotlin/commands/YanCommands.kt
+++ b/src/main/kotlin/commands/YanCommands.kt
@@ -5,9 +5,11 @@ import com.github.YanConfig
 import com.github.YanData
 import net.mamoe.mirai.console.command.CommandSenderOnMessage
 import net.mamoe.mirai.console.command.CompositeCommand
+import net.mamoe.mirai.console.command.SimpleCommand.Handler
 import net.mamoe.mirai.contact.User
 import net.mamoe.mirai.contact.nameCardOrNick
 import net.mamoe.mirai.event.events.GroupMessageEvent
+import net.mamoe.mirai.event.events.MessageEvent
 
 object YanCommands : CompositeCommand(
     XXYan,
@@ -18,6 +20,12 @@ object YanCommands : CompositeCommand(
     suspend fun CommandSenderOnMessage<GroupMessageEvent>.length(user: User) {
         val sequence = YanData.getSequence(user.id)
         fromEvent.group.sendMessage("目前该用户的yan数量为:${sequence.rowSet.size()}")
+    }
+
+    @SubCommand
+    suspend fun CommandSenderOnMessage<MessageEvent>.unsetYan(name: String) {
+        val value = YanConfig.cares.remove(name)
+        fromEvent.subject.sendMessage("已成功移除${name} -> $value")
     }
 
     @SubCommand

--- a/src/main/kotlin/commands/YanCommands.kt
+++ b/src/main/kotlin/commands/YanCommands.kt
@@ -5,11 +5,9 @@ import com.github.YanConfig
 import com.github.YanData
 import net.mamoe.mirai.console.command.CommandSenderOnMessage
 import net.mamoe.mirai.console.command.CompositeCommand
-import net.mamoe.mirai.console.command.SimpleCommand.Handler
 import net.mamoe.mirai.contact.User
 import net.mamoe.mirai.contact.nameCardOrNick
 import net.mamoe.mirai.event.events.GroupMessageEvent
-import net.mamoe.mirai.event.events.MessageEvent
 
 object YanCommands : CompositeCommand(
     XXYan,
@@ -20,12 +18,6 @@ object YanCommands : CompositeCommand(
     suspend fun CommandSenderOnMessage<GroupMessageEvent>.length(user: User) {
         val sequence = YanData.getSequence(user.id)
         fromEvent.group.sendMessage("目前该用户的yan数量为:${sequence.rowSet.size()}")
-    }
-
-    @SubCommand
-    suspend fun CommandSenderOnMessage<MessageEvent>.unsetYan(name: String) {
-        val value = YanConfig.cares.remove(name)
-        fromEvent.subject.sendMessage("已成功移除${name} -> $value")
     }
 
     @SubCommand

--- a/src/main/kotlin/commands/YanConsoleCommands.kt
+++ b/src/main/kotlin/commands/YanConsoleCommands.kt
@@ -1,0 +1,35 @@
+package com.github.commands
+
+import com.github.XXYan
+import com.github.YanConfig
+import com.github.YanData
+import net.mamoe.mirai.console.command.CompositeCommand
+import net.mamoe.mirai.console.command.ConsoleCommandSender
+
+object YanConsoleCommands : CompositeCommand(
+    XXYan,
+    "yanConsole",
+    parentPermission = XXYan.permission
+) {
+    @SubCommand
+    suspend fun ConsoleCommandSender.length(userId: Long) {
+        val sequence = YanData.getSequence(userId)
+        this.sendMessage("目前该用户的yan数量为:${sequence.rowSet.size()}")
+    }
+
+    @SubCommand
+    suspend fun ConsoleCommandSender.unsetYan(name: String) {
+        val value = YanConfig.cares.remove(name)
+        this.sendMessage("已成功移除${name} -> $value")
+    }
+
+    @SubCommand
+    suspend fun ConsoleCommandSender.stars() {
+        val sequence = YanConfig.cares
+        val ids = sequence.values.toSet()
+        this.sendMessage("目前关注的人有:\n${ids.joinToString("\n")}")
+    }
+
+
+}
+

--- a/src/test/kotlin/test.kt
+++ b/src/test/kotlin/test.kt
@@ -1,1 +1,16 @@
 package com.github
+
+import net.mamoe.mirai.console.MiraiConsole
+import net.mamoe.mirai.console.plugin.PluginManager.INSTANCE.enable
+import net.mamoe.mirai.console.plugin.PluginManager.INSTANCE.load
+import net.mamoe.mirai.console.terminal.MiraiConsoleTerminalLoader.startAsDaemon
+
+
+suspend fun main() {
+    startAsDaemon()
+
+    XXYan.load()
+    XXYan.enable()
+
+    MiraiConsole.job.join()
+}


### PR DESCRIPTION
1. `data\\yan.db`的写法当我在linux服务器运行时，得到的是mcl目录下的 `data\yan.db`文件，应该修改代码写法。更合适的应该是基于plugin所属data目录，即用`resolveDataFile`。（此时数据路径改变，若发新版应指导用户移动）
![N7%XD83{X3 74WCM@MN L$R](https://user-images.githubusercontent.com/22592888/179129732-369b9648-0bbb-4a79-877e-ce5a21172635.jpg)
2. `cares`默认值`1 to 1L`，导致bot对所有“1”开头的发言进行指令匹配并搜索然后得到“搜索失败,请重试”。而新手用户不容易发现问题原因。故修改 `cares`默认值。
3. 发生2时，缺少`移除订阅`指令。另一方便，为了方便在console里执行一些操作。新增`YanConsoleCommands`。
![image](https://user-images.githubusercontent.com/22592888/179665458-a0b48236-772e-469a-9509-4cb37c718bf8.png)
4. 通过`tryAlterColumn`协助旧版表里没有`title`的用户升级
5. 将`me.liuwj.ktorm`改为`org.ktorm`且升为3.5.0
6. 其他小优化：移除未被使用的head、IO交给Dispatchers.IO、ExternalResource应关闭……