### PR TITLE
fix draw multi-line-text bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # User-specific stuff
+testOutput.png
+
 .idea/
 
 *.iml

--- a/build.gradle
+++ b/build.gradle
@@ -18,4 +18,5 @@ repositories {
 dependencies{
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
     implementation 'org.ktorm:ktorm-core:3.5.0'
+    testImplementation "junit:junit:4.11"
 }

--- a/src/main/kotlin/XXYan.kt
+++ b/src/main/kotlin/XXYan.kt
@@ -95,7 +95,11 @@ object XXYan : KotlinPlugin(JvmPluginDescription(
                     val image = MessagePainter.paintMessage(
                         Yan(
                             Sender(
-                                YanConfig.NameMap[YanConfig.cares[args[1]]] ?: yan.name, yan.head, 1,yan.title, "red"
+                                YanConfig.NameMap[YanConfig.cares[args[1]]] ?: yan.name,
+                                { MessagePainter.downloadAvatar(yan.head) },
+                                1,
+                                yan.title,
+                                "red"
                             ),
                             chain
                         )

--- a/src/main/kotlin/YanData.kt
+++ b/src/main/kotlin/YanData.kt
@@ -31,7 +31,8 @@ class YanData(id: Long) : Table<YanEntity>(id.toString()) {
                 }
                 XXYan.logger.info("alterColumn done for ${this@tryAlterColumn.tableName}.$columnName")
             } catch (e: SQLException) {
-                XXYan.logger.info("alterColumn fail for ${this@tryAlterColumn.tableName}.$columnName, Most likely it already exists")
+                // alterColumn fail for ${this@tryAlterColumn.tableName}.$columnName, Most likely it already exists
+                // do nothing
             }
         }
 

--- a/src/main/kotlin/core/MessagePainter.kt
+++ b/src/main/kotlin/core/MessagePainter.kt
@@ -90,8 +90,8 @@ object MessagePainter {
         var image = BufferedImage(680, 70, BufferedImage.TYPE_4BYTE_ABGR)
         var cg2d: Graphics2D = image.createGraphics()
         cg2d.font = standardFont.deriveFont(40f)
-        val list = Vector<String>()
         fun split(text: String, fontMetrics: FontMetrics, max: Int): List<String> {
+            val list = Vector<String>()
             var num = 1
             if (fontMetrics.stringWidth(text.subSequence(0, text.length) as String) <= max) {
                 list.add(text)
@@ -169,13 +169,13 @@ object MessagePainter {
     }
 
     private fun drawAvatar(yan: Yan, image: BufferedImage) {
-        val avatar = downloadAvatar(yan.sender.avatar).circleAvatar()
+        val avatar = yan.sender.avatarProvider.invoke().circleAvatar()
         val g2d = image.createGraphics()
         g2d.applyAntialias()
         g2d.drawImage(avatar, 25, 20, 110, 110, null)
     }
 
-    private fun downloadAvatar(url: String): BufferedImage {
+    fun downloadAvatar(url: String): BufferedImage {
         return ImageIO.read(URL(url))
     }
 

--- a/src/main/kotlin/core/data/Sender.kt
+++ b/src/main/kotlin/core/data/Sender.kt
@@ -1,10 +1,11 @@
 package com.github.core.data
 
+import java.awt.image.BufferedImage
 
-@kotlinx.serialization.Serializable
+
 data class Sender(
     val name:String,
-    val avatar:String,
+    val avatarProvider:(() -> BufferedImage),
     val id:Long,
     val title:String,
     val titleColor:String,

--- a/src/main/kotlin/core/data/Yan.kt
+++ b/src/main/kotlin/core/data/Yan.kt
@@ -2,7 +2,7 @@ package com.github.core.data
 
 import net.mamoe.mirai.message.data.MessageChain
 
-@kotlinx.serialization.Serializable
+
 data class Yan(
     val sender: Sender,
     val message: MessageChain

--- a/src/test/java/com/github/SimpleGeometricImageProvider.java
+++ b/src/test/java/com/github/SimpleGeometricImageProvider.java
@@ -1,0 +1,53 @@
+package com.github;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+public class SimpleGeometricImageProvider {
+    public static BufferedImage apply(String key) {
+        try {
+            String[] args = key.split(" ");
+            String type = args[0];
+            if (type.equals("矩形")) {
+                String[] sizeParts = args[1].split(",");
+                int width = Integer.parseInt(sizeParts[0]);
+                int height = Integer.parseInt(sizeParts[1]);
+
+                String[] colorParts = args[2].split(",");
+                String colorType = colorParts[0];
+                Paint paint;
+                if (colorType.contains("渐变")) {
+                    Color colorFrom = new Color(Integer.parseInt(colorParts[1]),
+                            Integer.parseInt(colorParts[2]),
+                            Integer.parseInt(colorParts[3]),
+                            Integer.parseInt(colorParts[4]));
+                    Color colorTo = new Color(Integer.parseInt(colorParts[5]),
+                            Integer.parseInt(colorParts[6]),
+                            Integer.parseInt(colorParts[7]),
+                            Integer.parseInt(colorParts[8]));
+                    if (colorType.equals("上下渐变")) {
+                        paint = new GradientPaint((int)(width / 2), 0, colorFrom, (int)(width / 2), height, colorTo);
+                    } else if (colorType.equals("左右渐变")) {
+                        paint = new GradientPaint(0, (int)(height / 2), colorFrom, width, (int)(height / 2), colorTo);
+                    } else {
+                        paint = new GradientPaint((int)(width / 2), 0, colorFrom, (int)(width / 2), height, colorTo);
+                    }
+                } else {
+                    paint = new Color(Integer.parseInt(colorParts[0]),
+                            Integer.parseInt(colorParts[1]),
+                            Integer.parseInt(colorParts[2]),
+                            Integer.parseInt(colorParts[3]));
+                }
+
+                BufferedImage result = new BufferedImage(width, height, BufferedImage.TYPE_4BYTE_ABGR);
+                Graphics2D graphics = result.createGraphics();
+                graphics.setPaint(paint);
+                graphics.fillRect(0, 0, result.getWidth(), result.getHeight());
+                return result;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("处理key=%s时异常", key), e);
+        }
+        throw new RuntimeException(String.format("无法处理key=%s", key));
+    }
+}

--- a/src/test/kotlin/MessagePainterTest.kt
+++ b/src/test/kotlin/MessagePainterTest.kt
@@ -1,0 +1,66 @@
+package com.github
+
+import com.github.core.MessagePainter
+import com.github.core.data.Sender
+import com.github.core.data.Yan
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import net.mamoe.mirai.message.data.MessageChainBuilder
+import net.mamoe.mirai.message.data.PlainText
+import org.junit.Test
+import java.io.*
+import javax.imageio.ImageIO
+
+
+class MessagePainterTest {
+
+    @Test
+    fun testblock() {
+        runBlocking { test() }
+    }
+
+    suspend fun test() {
+        val avatarProvider = {SimpleGeometricImageProvider.apply("矩形 50,50 上下渐变,3,74,144,255,10,151,223,255")}
+        val messageChain = MessageChainBuilder()
+            .append(PlainText("""
+                foo
+                bar
+                yan
+            """.trimIndent()))
+            .build()
+        val image = MessagePainter.paintMessage(
+            Yan(
+                Sender(
+                    "testName",
+                    avatarProvider,
+                    1,
+                    "testTitle",
+                    "red"
+                ),
+                messageChain
+            )
+        )
+
+        val byteStream = ByteArrayOutputStream()
+        withContext(Dispatchers.IO) {
+            ImageIO.write(image, "png", byteStream)
+        }
+        copyInputStreamToFile(ByteArrayInputStream(byteStream.toByteArray()), File("testOutput.png"))
+    }
+}
+
+fun copyInputStreamToFile(inputStream: InputStream, file: File?) {
+    // append = false
+    try {
+        FileOutputStream(file, false).use { outputStream ->
+            var read: Int
+            val bytes = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (inputStream.read(bytes).also { read = it } != -1) {
+                outputStream.write(bytes, 0, read)
+            }
+        }
+    } catch (ex: Exception) {
+        ex.printStackTrace()
+    }
+}


### PR DESCRIPTION
bug:
当PlainText原本就是多行时可复现。
```
val messageChain = MessageChainBuilder()
            .append(PlainText("""
                foo
                bar
                yan
            """.trimIndent()))
            .build()
```
绘制结果为：
![testOutput old](https://user-images.githubusercontent.com/22592888/180121717-5831a76d-60fc-4edc-b8e8-e1988bc1ddf8.png)

关键改动：
`fun split`中`val list`应表示本次text分割结果，故应每次创建新实例。不应和表示累计结果的`val new`混淆。

其余改动：
目的是为了让`MessagePainter.paintMessage`可以被单元测试。
- `data class Yan`改为既可以从url提供图片，也可以其它方式提供图片(例如`SimpleGeometricImageProvider`绘制的BufferedImage)。也方便未来迭代其他用法。
- `SimpleGeometricImageProvider`仅是为单元测试提供BufferedImage的工具，与插件逻辑无关，无需关心内部实现。如果未来有更合适的为单元测试提供BufferedImage的方式，可将其替换。
- `data class Yan`和`data class Sender`不应该Serializable，因为设计上他们不会被储存或传输。另外未来可以考虑`class Yan`重命名得更易懂，例如`class YanDrawTask`

修复后：
![testOutput](https://user-images.githubusercontent.com/22592888/180123426-84a0d75d-f470-4f51-aa05-b457c162fb14.png)
